### PR TITLE
Add maintainer loop (orchestrator + triage skills)

### DIFF
--- a/.claude/skills/github-project-triage/SKILL.md
+++ b/.claude/skills/github-project-triage/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: github-project-triage
+description: >-
+  Triage GitHub issues and PRs into maintainer-facing item cards and sort them
+  into autonomous / needs-owner / defer buckets. Use when asked to "triage" a
+  repo or the backlog, or as the first step of the maintainer-orchestrator loop.
+  Defaults to the current repo; only goes org-wide when explicitly told ("all",
+  "broad", "org-wide").
+---
+
+# GitHub Project Triage
+
+Turn an open queue into decisions. Triage produces **item cards** a maintainer
+can act on, then sorts them so the orchestrator knows what to do.
+
+## Scope
+
+- If invoked inside a Git repo with a GitHub remote (or a Routine cloned a
+  specific repo), triage **only that repo**.
+- Only broaden to multiple repos / the whole `ITSEZMONEY` org when the prompt
+  explicitly says `all`, `broad`, `org-wide`, or `everything`.
+
+## Discover the queue
+
+Use the **GitHub MCP connector** (preferred) or `gh`:
+- Open PRs (with CI status, requested reviewers, draft state, mergeability).
+- Open issues (with labels, age, last activity).
+- For each, the last few comments and the CI job summary.
+
+There is no `repobar` dependency — query GitHub directly. Batch reads where the
+connector allows it; don't fetch full logs until an item needs them.
+
+## Item card
+
+For every open issue/PR, produce:
+
+| Field | What to capture |
+| --- | --- |
+| **URL / #** | Direct link. |
+| **What** | One line: what this issue/PR is. |
+| **Why it matters** | Impact / who it affects. |
+| **Author trust** | Org member · trusted bot (Dependabot/Renovate) · returning contributor · first-time / unknown. State the signal, not a vibe. |
+| **Type** | bug · feature · dependency · security · docs · chore |
+| **Fit** | good / mixed / poor + one-line reason (does it match the product?). |
+| **Risk** | low / medium / high + blast radius (what breaks if wrong). |
+| **Proof** | CI state · local repro · test coverage · manual/E2E validation. |
+| **Blockers** | Missing repro, failing CI, needs decision, needs creds, merge conflict. |
+| **Next action** | The single concrete next step. |
+
+Trust informs **review depth, not correctness** — a trusted author still needs
+green CI and a sane diff; an unknown author with a perfect, tested patch can
+still land. Cite factual signals (account age, prior merged PRs, review history)
+rather than impressions.
+
+## Risk heuristics (ITSEZMONEY / gate-slip context)
+
+Treat as **high risk** anything touching: auth/Passport/OAuth, payments/Stripe,
+`certificates/` or any key/secret, DB schema or migrations (`shared/schema.ts`),
+the parsing pipeline's output shape (`flightDataSchema`, the dual-AI parsers),
+or CI/release/`.env` config. Treat docs, copy, tests, lockfile/dep bumps, and
+formatting as **low risk**.
+
+## Buckets
+
+Sort every card into exactly one:
+
+1. **Autonomous** — fixable without product input. Note a confidence level and
+   why it's safe. (The orchestrator's autonomy policy decides land-vs-draft.)
+2. **Needs owner** — blocked on a decision, direction, missing credentials, or
+   high-risk surface. State the exact decision required and the options.
+3. **Defer / close** — stale, duplicate, superseded, or out of scope. Give the
+   reason and the canonical item if it's a duplicate.
+
+## Output
+
+Group the cards by bucket, most actionable first. Keep each card to a few lines.
+End with a one-line tally (`N autonomous · M needs-owner · K defer`). When run as
+the orchestrator's first step, hand this structured result back rather than
+printing a wall of text.

--- a/.claude/skills/maintainer-orchestrator/SKILL.md
+++ b/.claude/skills/maintainer-orchestrator/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: maintainer-orchestrator
+description: >-
+  Control-plane loop for maintaining ITSEZMONEY repositories. Use when asked to
+  "maintain the repos", "run the maintainer loop", "triage and act on the
+  backlog", or when invoked by a scheduled/API/GitHub-event cloud Routine. It
+  inspects issues/PRs/CI across one or more repos, classifies each item as
+  autonomous / needs-owner / defer, lands low-risk work autonomously, escalates
+  the rest, and records state in a durable ledger issue.
+---
+
+# Maintainer Orchestrator
+
+A **control-plane** skill: inspect, classify, act, monitor, and report. It does
+not invent product direction — it moves the existing backlog toward a clean,
+green, reviewed state and escalates anything that needs a human decision.
+
+This skill is designed to run **autonomously inside a Claude Code Routine**
+(`claude.ai/code/routines`) — a cloud session with no permission prompts — but
+also works when invoked by hand in an interactive session.
+
+## The loop (one run)
+
+Each run is one pass. Do these in order, then stop.
+
+1. **Scope.** Determine the target repositories.
+   - If the Routine cloned multiple repos, act on all of them.
+   - If invoked in a single repo with a GitHub remote, act on that repo only.
+   - Do **not** broaden beyond the cloned/selected repos unless the prompt says
+     `all` / `org-wide`.
+2. **Triage.** Invoke the `github-project-triage` skill to build item cards for
+   every open issue and PR (URL, what/why, author trust, fit, risk, proof/test
+   state, blockers, next action) and sort them into three buckets:
+   **autonomous · needs-owner · defer/close**.
+3. **Read the ledger.** Find the open issue titled `🤖 Maintainer Loop — Ledger`
+   in each repo (create it if missing). It is the durable memory across runs
+   since cloud sessions are ephemeral. Skip anything the ledger already marks
+   resolved or `wontfix`.
+4. **Act on autonomous items**, one at a time, verifying each before moving on
+   (see *Autonomy policy* below). Stop touching an item the moment it stops
+   meeting the bar and reclassify it as needs-owner.
+5. **Escalate needs-owner items.** Don't guess at product/direction/secret
+   decisions. Label `needs-owner`, leave a one-paragraph comment stating the
+   decision required and the options, and record it in the ledger.
+6. **Defer/close** stale, duplicate, or superseded items with a short reason.
+7. **Report.** Update the ledger issue with what changed this run (landed,
+   escalated, deferred, still-in-flight) and the timestamp. Keep it skimmable.
+
+Then end the run. The next trigger starts the next pass.
+
+## Autonomy policy
+
+The owner has authorized **auto-merge for low-risk work**. Be conservative:
+when in doubt, downgrade to a draft PR and escalate.
+
+### Low-risk → may land autonomously (open PR, get CI green, then merge)
+
+ALL must hold:
+- CI is **fully green** on the head commit (not pending, not skipped-as-proxy).
+- The change is one of: dependency patch/minor bump that is non-breaking,
+  lockfile sync, docs/comments/typo, formatting or lint autofix, test-only
+  additions, or a clearly-scoped config tweak.
+- Diff is small and bounded (rule of thumb: ≤ ~50 changed lines, single
+  concern).
+- It touches **none** of: auth, payments/Stripe, `certificates/` or any
+  key/secret, DB schema or migrations (`shared/schema.ts`, drizzle), CI/release
+  config, or anything in `.env*`.
+- Author is trusted (org member, or a bot like Dependabot/Renovate) **or** the
+  change was authored by this loop.
+- No unresolved review thread requests changes.
+- Branch is up to date with base (or can be safely fast-forward updated).
+
+For these: ensure CI is green, then **merge** (squash by default). If the loop
+authored the fix, open the PR first, let CI run, then merge once green.
+
+### Everything else → draft PR + escalate, never auto-merge
+
+Bugs with real logic changes, features, anything touching the protected areas
+above, large diffs, untrusted authors, red/uncertain CI, or any ambiguity:
+open or leave a **draft** PR with your analysis, label `needs-owner`, and record
+it in the ledger. Do not merge.
+
+### Never
+
+- Force-push to or merge into protected/long-lived branches outside the PR flow.
+- Touch certificates, private keys, or secrets.
+- Close an item a human is actively discussing.
+- Make product/pricing/architecture decisions.
+
+## CI babysitting
+
+When you open or own a PR, drive its CI to green: read failing job logs,
+reproduce locally when possible, push the fix, re-check. Re-kick on each failure
+rather than treating one round as the job. If a failure is real and out of scope
+or you've re-kicked several times without progress, escalate with the diagnosis
+instead of looping forever.
+
+## Parallelization (worker fan-out)
+
+Within a single run you may fan out read-only investigation across repos/items
+using the `Agent` tool (one subagent per repo or per cluster of related items).
+Keep **mutations** (commits, merges, comments) on the main orchestrator thread so
+there is a single writer. Workers investigate and report; the orchestrator
+decides and acts. Workers must not spawn further workers.
+
+## Tools
+
+Use the **GitHub MCP connector** for all GitHub reads/writes (issues, PRs, CI
+status, job logs, merges, comments, labels); fall back to `gh` only if the
+connector is unavailable. Use `git` for local branch work. The `github-project-triage`
+skill provides the queue-discovery and scoring helpers.
+
+## The ledger
+
+One open issue per repo, titled exactly `🤖 Maintainer Loop — Ledger`, body
+rewritten each run. Suggested shape:
+
+```
+## Maintainer Loop — last run <UTC timestamp>
+
+### Landed this run
+- #123 bump zod 3.x → 3.y (deps, CI green) — merged
+
+### Needs owner
+- #130 Stripe webhook retry policy — needs decision: idempotency window? (options A/B)
+
+### In flight
+- #128 fix PDF parse crash — draft PR open, CI red, investigating
+
+### Deferred / closed
+- #99 closed as duplicate of #128
+```
+
+This is the only state that survives between runs — keep it accurate.
+
+## Reporting back to the owner
+
+A Routine run has no human present, so "escalation" means: the `needs-owner`
+label, a concise comment on the item, and a ledger entry. Do not block on
+`AskUserQuestion` (there is nobody to answer mid-run). If a connector is
+configured (Slack/Linear/etc.), a one-line summary of escalations is welcome,
+but the ledger is the source of truth.

--- a/docs/MAINTAINER_LOOP.md
+++ b/docs/MAINTAINER_LOOP.md
@@ -1,0 +1,113 @@
+# Maintainer Loop (cloud)
+
+A self-running maintenance loop for ITSEZMONEY repos: wake on a trigger → triage
+issues/PRs/CI → land low-risk work autonomously → escalate the rest → record
+state in a ledger issue. Built on two committed skills and **Claude Code
+Routines** (Anthropic's cloud automation), so it keeps running with no laptop
+open.
+
+- Playbook: [`.claude/skills/maintainer-orchestrator`](../.claude/skills/maintainer-orchestrator/SKILL.md)
+- Triage: [`.claude/skills/github-project-triage`](../.claude/skills/github-project-triage/SKILL.md)
+
+## How it maps to "wake every 5 min, direct work to threads"
+
+| Your model | Cloud equivalent |
+| --- | --- |
+| Always-on driver | A **Routine** on Anthropic's cloud (no laptop). |
+| Wake every N minutes | Routine **trigger** (schedule / GitHub event / API). |
+| Triage + classify | `github-project-triage` skill. |
+| Direct work to threads | Orchestrator fans out per-repo work with the `Agent` tool; mutations stay on one thread. |
+| Some work lands autonomously | Routines run with **no permission prompts**; autonomy policy gates what merges. |
+| Steer / report | The `🤖 Maintainer Loop — Ledger` issue (durable across runs). |
+
+## ⚠️ Cadence reality check
+
+Claude Code Routine **scheduled** triggers have a **one-hour minimum** — a true
+"every 5 minutes" schedule is rejected. Pick a trigger based on how reactive you
+need to be:
+
+| Want | Use | Notes |
+| --- | --- | --- |
+| Steady backlog sweeps | **Scheduled** trigger | Hourly is the floor; daily/weeknightly is usually plenty and cheaper. |
+| Real-time on PRs/releases | **GitHub event** trigger | Fires on `pull_request.*` / `release.*` — the closest thing to "instant". Subject to per-account hourly caps. |
+| Literal 5-minute polling | **API** trigger + external pinger | Your own cron/codex driver POSTs to the routine's `/fire` endpoint every 5 min. This is where a 5-min cadence actually lives. |
+
+You can attach **several triggers to one routine** — e.g. hourly sweep *plus*
+react to every new PR *plus* an API endpoint your driver can poke.
+
+## Setup (once per loop)
+
+Routines can't be created from inside a web session or via API — create them in
+the UI or with `/schedule` from a local CLI.
+
+1. **Commit the skills.** They must live in the repo(s) the routine clones —
+   that's what this PR does. The fan-out script (below) copies them to every
+   ITSEZMONEY repo.
+2. **Create the routine** at <https://claude.ai/code/routines> → **New routine**:
+   - **Repositories:** select the repos to maintain. One routine can clone
+     several, so a single org-maintainer routine can sweep them all in one run.
+   - **Environment:** `Default` (Trusted network) is fine. Add `DATABASE_URL`,
+     `ANTHROPIC_API_KEY`, etc. only if a run needs to actually build/run the app.
+   - **Connectors:** keep **GitHub**; drop the rest unless a run needs them.
+   - **Permissions:** enable **Allow unrestricted branch pushes** only if you
+     want it to push to existing branches; PR-merge of low-risk items works
+     without it.
+   - **Prompt:** paste the kickoff prompt below.
+   - **Trigger:** pick from the cadence table above.
+3. **Run now** once to seed the ledger issue and confirm behavior, then let the
+   trigger drive it.
+
+> Identity note: a routine acts as **you** — commits, PRs, and merges carry your
+> GitHub user, and it draws down your account's usage + daily routine-run cap.
+
+### Kickoff prompt (paste into the routine)
+
+```
+Load the maintainer-orchestrator skill and run one maintenance pass over every
+repository cloned for this run. Follow the skill's loop and autonomy policy
+exactly: triage, read/update the "🤖 Maintainer Loop — Ledger" issue, AUTO-MERGE
+only low-risk items (green CI; deps/docs/tests/lockfile/formatting; small diff;
+no auth/payments/certs/schema/CI/secrets; trusted author), open DRAFT PRs and
+label `needs-owner` for everything else, defer/close stale or duplicate items,
+then summarize the run in the ledger. Do not make product, pricing, or
+architecture decisions. When in doubt, escalate instead of merging.
+```
+
+## Autonomy policy (summary)
+
+Authorized level: **auto-merge low-risk**. Full rules in the orchestrator skill.
+
+- **Auto-merge** (squash) only when *all* hold: CI green · change is
+  deps/docs/tests/lockfile/formatting/safe-config · small bounded diff · touches
+  none of {auth, Stripe, `certificates/`, schema/migrations, CI/release, `.env*`,
+  secrets} · trusted author or loop-authored · no unresolved change requests.
+- **Draft PR + `needs-owner`** for anything else — bugs with real logic, features,
+  protected surfaces, big diffs, untrusted authors, uncertain CI, any ambiguity.
+- **Never** touch certs/keys/secrets, force-push protected branches, or close an
+  item under active discussion.
+
+## Fan out to all repos
+
+```bash
+# Copy the skills + this runbook into every ITSEZMONEY repo and open a PR each.
+scripts/fanout-maintainer-skills.sh                 # all org repos (needs gh + perms)
+scripts/fanout-maintainer-skills.sh repo-a repo-b   # just these
+```
+
+The script is idempotent — re-running it updates the skills on the branch and
+refreshes the PR. After it runs, add each repo to your maintainer routine (or
+give each its own routine).
+
+## Alternative: GitHub Actions (true 5-min, BYO key)
+
+If you'd rather not depend on Routines for sub-hour cadence, a scheduled Action
+(`on: schedule: cron`, 5-min floor) can run the Claude Code GitHub Action with
+the same kickoff prompt and an `ANTHROPIC_API_KEY` secret. It's more setup and
+burns Action minutes + API spend per repo, so prefer Routines unless you need
+the tighter cadence in CI. See <https://code.claude.com/docs/en/github-actions>.
+
+## References
+
+- Routines / scheduled tasks: <https://code.claude.com/docs/en/web-scheduled-tasks>
+- Claude Code on the web: <https://code.claude.com/docs/en/claude-code-on-the-web>
+- Skills: <https://code.claude.com/docs/en/skills>


### PR DESCRIPTION
Adds the maintainer loop tooling copied from gate-slip:

- `.claude/skills/maintainer-orchestrator/`
- `.claude/skills/github-project-triage/`
- `docs/MAINTAINER_LOOP.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01F56rbEeokJBn7qDwWSouJs)_